### PR TITLE
Fix: Update deprecated JWT library to golang-jwt/jwt/v5

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ The **User Auth and Permissions** service is a robust, scalable **Golang** backe
   - [GORM](https://gorm.io/) for ORM and database interaction.
   - [Tonic](https://github.com/loopfz/golang-swiss-army-knife/tree/master/tonic) for parameter binding in **Gin**.
 - **Database**: [PostgreSQL](https://www.postgresql.org/)
-- **Authentication**: [JWT](https://github.com/dgrijalva/jwt-go)
+- **Authentication**: [JWT](https://github.com/golang-jwt/jwt)
 - **Migrations**: [golang-migrate](https://github.com/golang-migrate/migrate)
 - **Testing**: [TestContainers](https://github.com/testcontainers/testcontainers-go) for integration testing.
 

--- a/go.mod
+++ b/go.mod
@@ -5,8 +5,8 @@ go 1.22.0
 toolchain go1.22.8
 
 require (
-	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/gin-gonic/gin v1.10.0
+	github.com/golang-jwt/jwt/v5 v5.3.0
 	github.com/golang-migrate/migrate/v4 v4.18.1
 	github.com/joho/godotenv v1.5.1
 	github.com/lib/pq v1.10.9

--- a/go.sum
+++ b/go.sum
@@ -27,8 +27,6 @@ github.com/creack/pty v1.1.18/go.mod h1:MOBLtS5ELjhRRrroQr9kyvTxUAFNvYEK993ew/Vr
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/dgrijalva/jwt-go v3.2.0+incompatible h1:7qlOGliEKZXTDg6OTjfoBKDXWrumCAMpl/TFQ4/5kLM=
-github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dhui/dktest v0.4.3 h1:wquqUxAFdcUgabAVLvSCOKOlag5cIZuaOjYIBOWdsR0=
 github.com/dhui/dktest v0.4.3/go.mod h1:zNK8IwktWzQRm6I/l2Wjp7MakiyaFWv4G1hjmodmMTs=
 github.com/distribution/reference v0.6.0 h1:0IXCQ5g4/QMHHkarYzh5l+u8T3t73zM5QvfrDyIgxBk=
@@ -66,6 +64,8 @@ github.com/goccy/go-json v0.10.2 h1:CrxCmQqYDkv1z7lO7Wbh2HN93uovUHgrECaO5ZrCXAU=
 github.com/goccy/go-json v0.10.2/go.mod h1:6MelG93GURQebXPDq3khkgXZkazVtN9CRI+MGFi0w8I=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
+github.com/golang-jwt/jwt/v5 v5.3.0 h1:pv4AsKCKKZuqlgs5sUmn4x8UlGa0kEVt/puTpKx9vvo=
+github.com/golang-jwt/jwt/v5 v5.3.0/go.mod h1:fxCRLWMO43lRc8nhHWY6LGqRcf+1gQWArsqaEUEa5bE=
 github.com/golang-migrate/migrate/v4 v4.18.1 h1:JML/k+t4tpHCpQTCAD62Nu43NUFzHY4CV3uAuvHGC+Y=
 github.com/golang-migrate/migrate/v4 v4.18.1/go.mod h1:HAX6m3sQgcdO81tdjn5exv20+3Kb13cmGli1hrD6hks=
 github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=

--- a/middlewares/auth.go
+++ b/middlewares/auth.go
@@ -5,7 +5,7 @@ import (
 	"net/http"
 	"os"
 
-	"github.com/dgrijalva/jwt-go"
+	"github.com/golang-jwt/jwt/v5"
 	"github.com/gin-gonic/gin"
 )
 

--- a/middlewares/auth_test.go
+++ b/middlewares/auth_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/dgrijalva/jwt-go"
+	"github.com/golang-jwt/jwt/v5"
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/assert"
 )

--- a/models/claim.go
+++ b/models/claim.go
@@ -1,6 +1,6 @@
 package models
 
-import "github.com/dgrijalva/jwt-go"
+import "github.com/golang-jwt/jwt/v5"
 
 type Claims struct {
 	Email      string `json:"email"`
@@ -8,5 +8,5 @@ type Claims struct {
 	FirstName  string `json:"first_name"`
 	MiddleName string `json:"middle_name"`
 	LastName   string `json:"last_name"`
-	jwt.StandardClaims
+	jwt.RegisteredClaims
 }

--- a/utils/jwt.go
+++ b/utils/jwt.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"time"
 
-	"github.com/dgrijalva/jwt-go"
+	"github.com/golang-jwt/jwt/v5"
 	"github.com/shibbirmcc/user-auth-and-permissions/models"
 )
 
@@ -24,8 +24,8 @@ func GenerateJWT(email string, userDetails models.UserDetail) (string, error) {
 		FirstName:  userDetails.FirstName,
 		MiddleName: userDetails.MiddleName,
 		LastName:   userDetails.LastName,
-		StandardClaims: jwt.StandardClaims{
-			ExpiresAt: expirationTime.Unix(),
+		RegisteredClaims: jwt.RegisteredClaims{
+			ExpiresAt: jwt.NewNumericDate(expirationTime),
 		},
 	}
 	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)

--- a/utils/jwt_test.go
+++ b/utils/jwt_test.go
@@ -4,7 +4,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/dgrijalva/jwt-go"
+	"github.com/golang-jwt/jwt/v5"
 	"github.com/shibbirmcc/user-auth-and-permissions/models"
 	"github.com/stretchr/testify/assert"
 )


### PR DESCRIPTION
## Summary
This PR fixes the deprecated JWT library issue that was causing potential security vulnerabilities and CI failures.

## Changes Made
- ✅ Replaced deprecated `github.com/dgrijalva/jwt-go` with `github.com/golang-jwt/jwt/v5`
- ✅ Updated `StandardClaims` to `RegisteredClaims` in models/claim.go
- ✅ Updated `ExpiresAt` field to use `jwt.NewNumericDate()` in utils/jwt.go
- ✅ Updated all import statements across utils, middlewares, and test files
- ✅ Updated README.md to reference the new JWT library
- ✅ All tests passing with the new JWT library implementation

## Why This Change?
The `github.com/dgrijalva/jwt-go` library has been deprecated and has known security vulnerabilities. The new `github.com/golang-jwt/jwt/v5` library is the official maintained fork that addresses these security concerns.

## Testing
- ✅ All unit tests pass
- ✅ JWT generation and validation working correctly
- ✅ Middleware authentication tests pass
- ✅ No breaking changes to existing functionality

## Security Impact
This change fixes potential security vulnerabilities present in the deprecated JWT library and ensures the application uses a maintained, secure JWT implementation.

Fixes potential CI failures related to deprecated dependencies.